### PR TITLE
Multilingual prefLabels now supported, as well as "lang=<language_code>" parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,13 +17,12 @@ if hasattr(config, 'VOCAB_CACHE_DAYS'):
 else:
     cache_seconds = 0
 
-vocabs_file_path = os.path.join(config.APP_DIR, 'VOCABS.p')
-if os.path.isfile(vocabs_file_path):
+if os.path.isfile(config.VOCAB_CACHE_PATH):
     # if the VOCABS.pickle file is older than VOCAB_CACHE_DAYS days, delete it
-    vocab_file_creation_time = os.stat(vocabs_file_path).st_mtime
+    vocab_file_creation_time = os.stat(config.VOCAB_CACHE_PATH).st_mtime
     # if the VOCABS.pickle file is older than VOCAB_CACHE_DAYS days, delete it
     if vocab_file_creation_time < time.time() - cache_seconds:
-        os.remove(vocabs_file_path)
+        os.remove(config.VOCAB_CACHE_PATH)
     
 @app.before_request
 def before_request():
@@ -38,15 +37,15 @@ def before_request():
     
 
     # we have no g.VOCABS so try and load it from a pickled VOCABS.p file
-    if os.path.isfile(vocabs_file_path):
+    if os.path.isfile(config.VOCAB_CACHE_PATH):
         try:
-            with open(vocabs_file_path, 'rb') as f:
+            with open(config.VOCAB_CACHE_PATH, 'rb') as f:
                 g.VOCABS = pickle.load(f)
                 f.close()
             if g.VOCABS: # Ignore empty file
                 return
         except Exception as e:
-            logging.debug('Unable to read vocab index file {}: {}'.format(vocabs_file_path, e))
+            logging.debug('Unable to read vocab index file {}: {}'.format(config.VOCAB_CACHE_PATH, e))
             pass
 
     # we haven't been able to load from VOCABS.p so run collect() on each vocab source to recreate it
@@ -60,7 +59,7 @@ def before_request():
 
     # also load all vocabs into VOCABS.p on disk for future use
     if g.VOCABS: # Don't write empty file
-        with open(vocabs_file_path, 'wb') as f:
+        with open(config.VOCAB_CACHE_PATH, 'wb') as f:
             pickle.dump(g.VOCABS, f)
             f.close()
 

--- a/app.py
+++ b/app.py
@@ -12,7 +12,19 @@ app = Flask(__name__, template_folder=config.TEMPLATES_DIR, static_folder=config
 
 app.register_blueprint(routes.routes)
 
+if hasattr(config, 'VOCAB_CACHE_DAYS'):
+    cache_seconds = config.VOCAB_CACHE_DAYS * 86400
+else:
+    cache_seconds = 0
 
+vocabs_file_path = os.path.join(config.APP_DIR, 'VOCABS.p')
+if os.path.isfile(vocabs_file_path):
+    # if the VOCABS.pickle file is older than VOCAB_CACHE_DAYS days, delete it
+    vocab_file_creation_time = os.stat(vocabs_file_path).st_mtime
+    # if the VOCABS.pickle file is older than VOCAB_CACHE_DAYS days, delete it
+    if vocab_file_creation_time < time.time() - cache_seconds:
+        os.remove(vocabs_file_path)
+    
 @app.before_request
 def before_request():
     """
@@ -24,27 +36,17 @@ def before_request():
     if hasattr(g, 'VOCABS'):
         return
     
-    if hasattr(config, 'VOCAB_CACHE_DAYS'):
-        cache_seconds = config.VOCAB_CACHE_DAYS * 86400
-    else:
-        cache_seconds = 0
 
     # we have no g.VOCABS so try and load it from a pickled VOCABS.p file
-    vocabs_file_path = os.path.join(config.APP_DIR, 'VOCABS.p')
     if os.path.isfile(vocabs_file_path):
-        # if the VOCABS.pickle file is older than VOCAB_CACHE_DAYS days, delete it
-        vocab_file_creation_time = os.stat(vocabs_file_path).st_mtime
         try:
-            if vocab_file_creation_time < time.time() - cache_seconds:
-                os.remove(vocabs_file_path)
-            # the file is less than VOCAB_CACHE_DAYS days old so use it
-            else:
-                with open(vocabs_file_path, 'rb') as f:
-                    g.VOCABS = pickle.load(f)
-                    f.close()
-                if g.VOCABS: # Ignore empty file
-                    return
-        except:
+            with open(vocabs_file_path, 'rb') as f:
+                g.VOCABS = pickle.load(f)
+                f.close()
+            if g.VOCABS: # Ignore empty file
+                return
+        except Exception as e:
+            logging.debug('Unable to read vocab index file {}: {}'.format(vocabs_file_path, e))
             pass
 
     # we haven't been able to load from VOCABS.p so run collect() on each vocab source to recreate it
@@ -53,7 +55,7 @@ def before_request():
     # using the appropriate class (from details['source']),
     # load all the vocabs from it into this session's (g) VOCABS variable
     g.VOCABS = {}
-    for name, details in config.VOCAB_SOURCES.items():
+    for _name, details in config.VOCAB_SOURCES.items():
         getattr(source, details['source']).collect(details)
 
     # also load all vocabs into VOCABS.p on disk for future use

--- a/controller/routes.py
+++ b/controller/routes.py
@@ -11,6 +11,7 @@ import json
 from pyldapi import Renderer
 import controller.sparql_endpoint_functions
 import datetime
+import logging
 
 routes = Blueprint('routes', __name__)
 
@@ -327,6 +328,11 @@ def endpoint():
     curl -H 'Accept: application/ld+json' http://localhost:5000/endpoint?query=PREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0APREFIX%20skos%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2004%2F02%2Fskos%2Fco23%3E%0ACONSTRUCT%20%7B%3Fs%20a%20rdf%3AResource%7D%0AWHERE%20%7B%3Fs%20a%20skos%3AConceptScheme%7D
 
     '''
+    logging.debug('request: {}'.format(request.__dict__))
+    
+    #TODO: Find a slightly less hacky way of getting the format_mimetime value
+    format_mimetype = request.__dict__.get('HTTP_ACCEPT')
+    
     # Query submitted
     if request.method == 'POST':
         '''Pass on the SPARQL query to the underlying endpoint defined in config
@@ -389,7 +395,7 @@ def endpoint():
                 )
             else:
                 return Response(
-                    controller.sparql_endpoint_functions.sparql_query(query),
+                    controller.sparql_endpoint_functions.sparql_query(query, format_mimetype),
                     status=200
                 )
         except ValueError as e:

--- a/controller/routes.py
+++ b/controller/routes.py
@@ -331,7 +331,7 @@ def endpoint():
     logging.debug('request: {}'.format(request.__dict__))
     
     #TODO: Find a slightly less hacky way of getting the format_mimetime value
-    format_mimetype = request.__dict__.get('HTTP_ACCEPT')
+    format_mimetype = request.__dict__['environ']['HTTP_ACCEPT']
     
     # Query submitted
     if request.method == 'POST':

--- a/controller/sparql_endpoint_functions.py
+++ b/controller/sparql_endpoint_functions.py
@@ -3,6 +3,7 @@ import io
 from rdflib import Graph
 from pyldapi import Renderer
 import _config as config
+import logging
 
 
 def get_sparql_service_description(rdf_format='turtle'):
@@ -41,19 +42,25 @@ def get_sparql_service_description(rdf_format='turtle'):
         raise ValueError('Input parameter rdf_format must be one of: ' + ', '.join(rdf_formats))
 
 
-def sparql_query(sparql_query, format_mimetype='application/sparql-results+json', sparql_username=None, sparql_password=None):
+def sparql_query(query, format_mimetype='application/json'):
     """ Make a SPARQL query"""
-    if sparql_username and sparql_password:
-        auth = (sparql_username, sparql_password)
-    else:
-        auth = None  # TODO: revert to auth'd query
-    data = {'query': sparql_query}
+    data = query
+    
     headers = {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Accept': format_mimetype
+        'Content-Type': 'application/sparql-query',
+        'Accept': format_mimetype,
+        'Accept-Encoding': 'UTF-8',
+        'HTTP_ACCEPT_ENCODING': 'gzip, deflate'
     }
+    if hasattr(config, 'SPARQL_USERNAME') and hasattr(config, 'SPARQL_PASSWORD'):
+        auth = (config.SPARQL_USERNAME, config.SPARQL_PASSWORD)
+    else:
+        auth = None
+        
     try:
-        r = requests.post(config.SPARQL_ENDPOINT, auth=auth, data=data, headers=headers, timeout=1)
+        logging.debug('endpoint={}\ndata={}\nheaders={}'.format(config.SPARQL_ENDPOINT, data, headers))
+        r = requests.post(config.SPARQL_ENDPOINT, auth=auth, data=data, headers=headers, timeout=60)
+        logging.debug('response: {}'.format(r.__dict__))
         return r.content.decode('utf-8')
     except Exception as e:
         raise e

--- a/controller/sparql_endpoint_functions.py
+++ b/controller/sparql_endpoint_functions.py
@@ -50,7 +50,6 @@ def sparql_query(query, format_mimetype='application/json'):
         'Content-Type': 'application/sparql-query',
         'Accept': format_mimetype,
         'Accept-Encoding': 'UTF-8',
-        'HTTP_ACCEPT_ENCODING': 'gzip, deflate'
     }
     if hasattr(config, 'SPARQL_USERNAME') and hasattr(config, 'SPARQL_PASSWORD'):
         auth = (config.SPARQL_USERNAME, config.SPARQL_PASSWORD)

--- a/data/source/FILE.py
+++ b/data/source/FILE.py
@@ -9,6 +9,8 @@ import logging
 from helper import APP_DIR
 
 
+global g # Flask globals
+
 class PickleLoadException(Exception):
     pass
 
@@ -23,8 +25,8 @@ class FILE(Source):
         'rdf': 'xml'
     }
 
-    def __init__(self, vocab_id, request):
-        super().__init__(vocab_id, request)
+    def __init__(self, vocab_id, request, language=None):
+        super().__init__(vocab_id, request, language)
         self.g = FILE.load_pickle_graph(vocab_id)
 
     @staticmethod

--- a/data/source/GITHUB.py
+++ b/data/source/GITHUB.py
@@ -6,8 +6,8 @@ from rdflib import Graph
 
 # TODO: implement GITHUB source
 class GITHUB(Source):
-    def __init__(self, vocab_id):
-        super().__init__(vocab_id)
+    def __init__(self, vocab_id, request, language=None):
+        super().__init__(vocab_id, request, language)
 
     def _parse_vocab(self):
         self.g = Graph().parse(join(config.APP_DIR, 'data', self.vocab_id + '.ttl'), format='turtle')

--- a/data/source/RVA.py
+++ b/data/source/RVA.py
@@ -12,8 +12,8 @@ class RVA(Source):
     """Source for Research Vocabularies Australia
     """
 
-    def __init__(self, vocab_id, request):
-        super().__init__(vocab_id, request)
+    def __init__(self, vocab_id, request, language=None):
+        super().__init__(vocab_id, request, language)
 
     @staticmethod
     def collect(details):

--- a/data/source/SPARQL.py
+++ b/data/source/SPARQL.py
@@ -17,8 +17,8 @@ class SPARQL(Source):
     """Source for a generic SPARQL endpoint
     """
 
-    def __init__(self, vocab_id, request):
-        super().__init__(vocab_id, request)
+    def __init__(self, vocab_id, request, language=None):
+        super().__init__(vocab_id, request, language)
 
     @staticmethod
     def collect(details):

--- a/data/source/VOCBENCH.py
+++ b/data/source/VOCBENCH.py
@@ -5,7 +5,9 @@ import _config as config
 from rdflib import Graph, Literal, URIRef
 import os
 from helper import APP_DIR
+from vocbench import Vocbench
 
+global g # Flask globals
 
 class VbAuthException(Exception):
     pass
@@ -16,8 +18,8 @@ class VbException(Exception):
 
 
 class VOCBENCH(Source):
-    def __init__(self, vocab_id, request):
-        super().__init__(vocab_id, request)
+    def __init__(self, vocab_id, request, language=None):
+        super().__init__(vocab_id, request, language)
 
     @staticmethod
     def init():

--- a/data/source/_source.py
+++ b/data/source/_source.py
@@ -8,6 +8,7 @@ from SPARQLWrapper import SPARQLWrapper, JSON, BASIC
 import dateutil
 from model.concept import Concept
 from collections import OrderedDict
+import logging
 
 # Default to English if no DEFAULT_LANGUAGE in config
 if hasattr(config, 'DEFAULT_LANGUAGE:'):
@@ -165,7 +166,6 @@ class Source:
                 OPTIONAL {{ <{concept_uri}> dct:modified ?modified }}
             }} }}""".format(concept_uri=self.request.values.get('uri'), 
                             language=self.language)
-        print(q)
         result = Source.sparql_query(vocab.sparql_endpoint, q, vocab.sparql_username, vocab.sparql_password)
 
         prefLabel = None
@@ -394,7 +394,7 @@ class Source:
                 g = Graph().parse(uri + '.ttl', format='turtle')
                 break
             except:
-                print('Failed to load resource at URI {}. Attempt: {}.'.format(uri, i+1))
+                logging.error('Failed to load resource at URI {}. Attempt: {}.'.format(uri, i+1))
         if not g:
             raise Exception('Failed to load Graph from {}. Maximum attempts exceeded {}.'.format(uri, max_attempts))
 

--- a/data/source/_source.py
+++ b/data/source/_source.py
@@ -394,7 +394,7 @@ class Source:
                 g = Graph().parse(uri + '.ttl', format='turtle')
                 break
             except:
-                logging.error('Failed to load resource at URI {}. Attempt: {}.'.format(uri, i+1))
+                logging.warning('Failed to load resource at URI {}. Attempt: {}.'.format(uri, i+1))
         if not g:
             raise Exception('Failed to load Graph from {}. Maximum attempts exceeded {}.'.format(uri, max_attempts))
 

--- a/data/source/_source.py
+++ b/data/source/_source.py
@@ -8,6 +8,7 @@ from SPARQLWrapper import SPARQLWrapper, JSON, BASIC
 import dateutil
 from model.concept import Concept
 from collections import OrderedDict
+from helper import make_title
 import logging
 
 # Default to English if no DEFAULT_LANGUAGE in config
@@ -134,39 +135,37 @@ class Source:
 
     def get_concept(self):
         vocab = g.VOCABS[self.vocab_id]
-        q = """
-            PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-            PREFIX dct: <http://purl.org/dc/terms/>
-            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-            PREFIX dc: <http://purl.org/dc/elements/1.1/>
-            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-            SELECT DISTINCT *
-            WHERE  {{ GRAPH ?g {{
-                {{ <{concept_uri}> skos:prefLabel ?prefLabel . # ?s skos:prefLabel|dct:title|rdfs:label ?prefLabel .
-                    # FILTER(lang(?prefLabel) = "{language}" || lang(?prefLabel) = "") 
-                    }}
-                OPTIONAL {{ <{concept_uri}> skos:definition ?definition .
-                    FILTER(lang(?definition) = "{language}" || lang(?definition) = "") }}
-                OPTIONAL {{ <{concept_uri}> skos:altLabel ?altLabel .
-                    FILTER(lang(?altLabel) = "{language}" || lang(?altLabel) = "") }}
-                OPTIONAL {{ <{concept_uri}> skos:hiddenLabel ?hiddenLabel .
-                    FILTER(lang(?hiddenLabel) = "{language}" || lang(?hiddenLabel) = "") }}
-                OPTIONAL {{ <{concept_uri}> dct:source ?source .
-                    FILTER(lang(?source) = "{language}" || lang(?source) = "") }}
-                OPTIONAL {{ <{concept_uri}> dct:contributor ?contributor .
-                    FILTER(lang(?contributor) = "{language}" || lang(?contributor) = "") }}
-                OPTIONAL {{ <{concept_uri}> skos:broader ?broader }}
-                OPTIONAL {{ <{concept_uri}> skos:narrower ?narrower }}
-                OPTIONAL {{ <{concept_uri}> skos:exactMatch ?exactMatch }}
-                OPTIONAL {{ <{concept_uri}> skos:closeMatch ?closeMatch }}
-                OPTIONAL {{ <{concept_uri}> skos:broadMatch ?broadMatch }}
-                OPTIONAL {{ <{concept_uri}> skos:narrowMatch ?narrowMatch }}
-                OPTIONAL {{ <{concept_uri}> skos:relatedMatch ?relatedMatch }}
-                OPTIONAL {{ <{concept_uri}> dct:created ?created }}
-                OPTIONAL {{ <{concept_uri}> dct:modified ?modified }}
-            }} }}""".format(concept_uri=self.request.values.get('uri'), 
+        q = """PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+SELECT DISTINCT *
+WHERE  {{ 
+    GRAPH ?g {{
+        {{ <{concept_uri}> skos:prefLabel ?prefLabel . # ?s skos:prefLabel|dct:title|rdfs:label ?prefLabel .
+            # FILTER(lang(?prefLabel) = "{language}" || lang(?prefLabel) = "") 
+            }}
+        OPTIONAL {{ <{concept_uri}> skos:definition ?definition .
+            FILTER(lang(?definition) = "{language}" || lang(?definition) = "") }}
+        OPTIONAL {{ <{concept_uri}> skos:altLabel ?altLabel .
+            FILTER(lang(?altLabel) = "{language}" || lang(?altLabel) = "") }}
+        OPTIONAL {{ <{concept_uri}> skos:hiddenLabel ?hiddenLabel .
+            FILTER(lang(?hiddenLabel) = "{language}" || lang(?hiddenLabel) = "") }}
+        OPTIONAL {{ <{concept_uri}> dct:source ?source .
+            FILTER(lang(?source) = "{language}" || lang(?source) = "") }}
+        OPTIONAL {{ <{concept_uri}> dct:contributor ?contributor .
+            FILTER(lang(?contributor) = "{language}" || lang(?contributor) = "") }}
+        OPTIONAL {{ <{concept_uri}> dct:created ?created }}
+        OPTIONAL {{ <{concept_uri}> dct:modified ?modified }}
+    }}
+}}""".format(concept_uri=self.request.values.get('uri'), 
                             language=self.language)
+            
+        print(q)
         result = Source.sparql_query(vocab.sparql_endpoint, q, vocab.sparql_username, vocab.sparql_password)
+        
+        assert result, 'Unable to query concepts for {}'.format(self.request.values.get('uri'))
 
         prefLabel = None
         definition = None
@@ -175,13 +174,7 @@ class Source:
         hiddenLabels = []
         source = None
         contributors = []
-        broaders = []
-        narrowers = []
-        exactMatches = []
-        closeMatches = []
-        broadMatches = []
-        narrowMatches = []
-        relatedMatches = []
+        
         for row in result:
             preflabel_lang = row['prefLabel'].get('xml:lang') or ''
             # Use default language or no language prefLabel as primary
@@ -213,67 +206,70 @@ class Source:
                 if row['contributor']['value'] is not None and row['contributor']['value'] not in contributors:
                     contributors.append(row['contributor']['value'])
 
-            if row.get('broader'):
-                if row['broader']['value'] is not None and row['broader']['value'] not in broaders:
-                    broaders.append(row['broader']['value'])
+        concept_relationships = {        
+            'broader': {},
+            'narrower': {},
+            'exactMatch': {},
+            'closeMatch': {},
+            'broadMatch': {},
+            'narrowMatch': {},
+            'relatedMatch': {},
+            }
+        
+        for relationship, related_concepts in concept_relationships.items():
+            print(relationship)
+            q = """PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+SELECT DISTINCT *
+WHERE  {{ 
+    GRAPH ?g {{
+        OPTIONAL {{ <{concept_uri}> skos:{relationship} ?{relationship} }}
+        OPTIONAL {{ ?{relationship} skos:prefLabel ?{relationship}Label .
+            FILTER(lang(?{relationship}Label) = "{language}" || lang(?{relationship}Label) = "") }}
+    }} 
+}}
+ORDER BY ?{relationship}""".format(concept_uri=self.request.values.get('uri'), 
+                                relationship=relationship,
+                                language=self.language)
+                
+            print(q)
+            result = Source.sparql_query(vocab.sparql_endpoint, q, vocab.sparql_username, vocab.sparql_password)
+            
+            assert result, 'Unable to query {} concepts for {}'.format(relationship, self.request.values.get('uri'))
 
-            if row.get('narrower'):
-                if row['narrower']['value'] is not None and row['narrower']['value'] not in narrowers:
-                    narrowers.append(row['narrower']['value'])
-
-            if row.get('exactMatch'):
-                if row['exactMatch']['value'] is not None and row['exactMatch']['value'] not in exactMatches:
-                    exactMatches.append(row['exactMatch']['value'])
-
-            if row.get('closeMatch'):
-                if row['closeMatch']['value'] is not None and row['closeMatch']['value'] not in closeMatches:
-                    closeMatches.append(row['closeMatch']['value'])
-
-            if row.get('broadMatch'):
-                if row['broadMatch']['value'] is not None and row['broadMatch']['value'] not in broadMatches:
-                    broadMatches.append(row['broadMatch']['value'])
-
-            if row.get('narrowMatch'):
-                if row['narrowMatch']['value'] is not None and row['narrowMatch']['value'] not in narrowMatches:
-                    narrowMatches.append(row['narrowMatch']['value'])
-
-            if row.get('relatedMatch'):
-                if row['relatedMatch']['value'] is not None and row['relatedMatch']['value'] not in relatedMatches:
-                    relatedMatches.append(row['relatedMatch']['value'])
+            for row in result:    
+                if row.get(relationship) and row[relationship].get('value'):
+                    relatedConceptLabel = (row[relationship+'Label']['value'] if row.get(relationship+'Label') and row[relationship+'Label'].get('value') 
+                                           else make_title(row[relationship]['value'])) # No prefLabel
+                    related_concepts[row[relationship]['value']] = relatedConceptLabel
 
         lang_prefLabels = OrderedDict([(key, lang_prefLabels[key]) 
                                        for key in sorted(lang_prefLabels.keys())])
         altLabels.sort()
         hiddenLabels.sort()
         contributors.sort()
-        broaders.sort()
-        narrowers.sort()
-        exactMatches.sort()
-        closeMatches.sort()
-        broadMatches.sort()
-        narrowMatches.sort()
-        relatedMatches.sort()
-
+        
+        for relationship, related_concepts in concept_relationships.items():
+            concept_relationships[relationship] = OrderedDict([(key, related_concepts[key]) 
+                                                          for key in sorted(related_concepts.keys())])
+            
         return Concept(
-            self.vocab_id,
-            vocab.uri,
-            prefLabel,
-            definition,
-            altLabels,
-            hiddenLabels,
-            source,
-            contributors,
-            broaders,
-            narrowers,
-            exactMatches,
-            closeMatches,
-            broadMatches,
-            narrowMatches,
-            relatedMatches,
-            None,
-            None,
-            None,
-            lang_prefLabels
+            vocab_id=self.vocab_id,
+            uri=vocab.uri,
+            prefLabel=prefLabel,
+            definition=definition,
+            altLabels=altLabels,
+            hiddenLabels=hiddenLabels,
+            source=source,
+            contributors=contributors,
+            concept_relationships=concept_relationships,
+            semantic_properties=None,
+            created=None,
+            modified=None,
+            lang_prefLabels=lang_prefLabels
         )
 
     def get_concept_hierarchy(self):
@@ -294,6 +290,8 @@ class Source:
             """.format(concept_scheme_uri=vocab.concept_scheme_uri, 
                        language=self.language)
         cs = Source.sparql_query(vocab.sparql_endpoint, q, vocab.sparql_username, vocab.sparql_password)
+        
+        assert cs, 'Unable to query concept hierarchy for conceptScheme {}'.format(vocab.concept_scheme_uri)
 
         hierarchy = []
         previous_parent_uri = None

--- a/model/concept.py
+++ b/model/concept.py
@@ -16,13 +16,7 @@ class Concept:
             hiddenLabels,
             source,
             contributors,
-            broaders,
-            narrowers,
-            exactMatches,
-            closeMatches,
-            broadMatches,
-            narrowMatches,
-            relatedMatches,
+            concept_relationships,
             semantic_properties,
             created,
             modified,
@@ -36,13 +30,7 @@ class Concept:
         self.hiddenLabels = hiddenLabels
         self.source = source
         self.contributors = contributors
-        self.broaders = broaders
-        self.narrowers = narrowers
-        self.exactMatches = exactMatches
-        self.closeMatches = closeMatches
-        self.broadMatches = broadMatches
-        self.narrowMatches = narrowMatches
-        self.relatedMatches = relatedMatches
+        self.concept_relationships = concept_relationships
         self.semantic_properties = semantic_properties
         self.created = created
         self.modified = modified

--- a/model/concept.py
+++ b/model/concept.py
@@ -25,7 +25,8 @@ class Concept:
             relatedMatches,
             semantic_properties,
             created,
-            modified
+            modified,
+            lang_prefLabels=None
     ):
         self.vocab_id = vocab_id
         self.uri = uri
@@ -45,6 +46,7 @@ class Concept:
         self.semantic_properties = semantic_properties
         self.created = created
         self.modified = modified
+        self.lang_prefLabels = lang_prefLabels
 
 
 class ConceptRenderer(Renderer):

--- a/model/vocabulary.py
+++ b/model/vocabulary.py
@@ -55,7 +55,7 @@ class Vocabulary:
 
 
 class VocabularyRenderer(Renderer):
-    def __init__(self, request, vocab):
+    def __init__(self, request, vocab, language='en'):
         self.views = self._add_dcat_view()
         self.navs = [
             # '<a href="' + url_for('routes.vocabulary', vocab_id=vocab.id) + '/collection/">Collections</a> |',
@@ -63,6 +63,7 @@ class VocabularyRenderer(Renderer):
         ]
 
         self.vocab = vocab
+        self.language = language
 
         super().__init__(
             request,

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -77,7 +77,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -21,7 +21,7 @@
 
     {% if concept.lang_prefLabels|length > 0 %}
     <tr>
-        <th>Other Language Labels</th>
+        <th style="padding-right: 10px;">Other Language Labels</th>
         <td class="list">
             {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
                 {{ prefLabel }} ({{ lang }})<br>
@@ -74,7 +74,7 @@
 
         {% if concept.concept_relationships[relationship] -%}
             <tr>
-                <th>{{relationship_label}}:</th>
+                <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
                     <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -24,7 +24,7 @@
         <th>Other Language Labels</th>
         <td class="list">
             {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
-                {{ prefLabel }} ({{ lang }})<br />
+                {{ prefLabel }} ({{ lang }})<br>
             {% endfor %}
         </td>
     </tr>
@@ -72,15 +72,17 @@
         ('narrower', 'Narrower'),
         ] %}
 
-        {% if concept.concept_relationships[relationship] %}
+        {% if concept.concept_relationships[relationship] -%}
             <tr>
                 <th>{{relationship_label}}:</th>
-                {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() %}
-                    <td><a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br /></td>
-                {% endfor %}
+                <td class="list">
+                    {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
+                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    {% endfor -%}
+                </td>
             </tr>
-        {% endif %}
-    {% endfor %}
+        {% endif -%}
+    {% endfor -%}
 
 </table>
 <hr>

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -18,6 +18,18 @@
         <td>{{ concept.date_modified }}</td>
     </tr>
     {% endif %}
+
+    {% if concept.lang_prefLabels|length > 0 %}
+    <tr>
+        <th>Other Language Labels</th>
+        <td class="list">
+            {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
+                {{ prefLabel }} ({{ lang }})
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+
     {% if concept.altLabels|length > 0 %}
     <tr>
         <th>Alternative Labels</th>

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -1,7 +1,7 @@
 {% extends "page.html" %}
 
 {% block content %}
-<h1>Concept: {{ concept.prefLabel }}</h1>
+<h1>{{ concept.prefLabel }}</h1>
 <h3>URI: <a href="{{ uri }}">{{ uri }}</a></h3>
 <h3>Within vocab <a href="{{ url_for('routes.vocabulary', vocab_id=vocab_id) }}">{{ vocab_title }}</a></h3>
 <table class="metadata concept">
@@ -24,7 +24,7 @@
         <th>Other Language Labels</th>
         <td class="list">
             {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
-                {{ prefLabel }} ({{ lang }})
+                {{ prefLabel }} ({{ lang }})<br />
             {% endfor %}
         </td>
     </tr>
@@ -63,73 +63,25 @@
 
     {% endif %}
 
-    {% if concept.exactMatches %}
-        <tr>
-            <th>has exact match:</th>
-            {% for match in concept.exactMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
+    {% for relationship, relationship_label in [
+        ('exactMatch', 'has exact match'),
+        ('closeMatch', 'has close match'),
+        ('broadMatch', 'has broad match'),
+        ('narrowMatch', 'has narrow match'),
+        ('broader', 'Broader'),
+        ('narrower', 'Narrower'),
+        ] %}
 
-    {% if concept.closeMatches %}
-        <tr>
-            <th>has close match:</th>
-            {% for match in concept.closeMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broadMatches %}
-        <tr>
-            <th>has broad match:</th>
-            {% for match in concept.broadMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.narrowMatches %}
-        <tr>
-            <th>has narrow match:</th>
-            {% for match in concept.narrowMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.relatedMatches %}
-        <tr>
-            <th>has related match:</th>
-            {% for match in concept.relatedMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broaders|length > 0 %}
-    <tr>
-        {% if concept.broaders %}
-        <th>Broader</th>
-        <td class="list">
-            {% for broader in concept.broaders -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(broader) }}">{{ h.make_title(broader) }}</a><br />
-            {% endfor %}
-        </td>
+        {% if concept.concept_relationships[relationship] %}
+            <tr>
+                <th>{{relationship_label}}:</th>
+                {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() %}
+                    <td><a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br /></td>
+                {% endfor %}
+            </tr>
         {% endif %}
-    </tr>
-    {% endif %}
-    {% if concept.narrowers %}
-    <tr>
-        <th style="padding-right: 10px;">Narrower: </th>
-        <td class="list">
-            {% for narrower in concept.narrowers -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(narrower) }}">{{ h.make_title(narrower) }}</a><br />
-            {% endfor %}
-        </td>
-    </tr>
-    {% endif %}
+    {% endfor %}
+
 </table>
 <hr>
 <h3>Alternate views</h3>

--- a/view/cgi/templates/concept.html
+++ b/view/cgi/templates/concept.html
@@ -77,7 +77,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
+                    <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/ga/templates/concept.html
+++ b/view/ga/templates/concept.html
@@ -77,7 +77,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/ga/templates/concept.html
+++ b/view/ga/templates/concept.html
@@ -18,6 +18,18 @@
         <td>{{ concept.date_modified }}</td>
     </tr>
     {% endif %}
+
+    {% if concept.lang_prefLabels|length > 0 %}
+    <tr>
+        <th>Other Language Labels</th>
+        <td class="list">
+            {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
+                {{ prefLabel }} ({{ lang }})
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+
     {% if concept.altLabels|length > 0 %}
     <tr>
         <th>Alternative Labels</th>

--- a/view/ga/templates/concept.html
+++ b/view/ga/templates/concept.html
@@ -77,7 +77,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
+                    <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/ga/templates/concept.html
+++ b/view/ga/templates/concept.html
@@ -21,10 +21,10 @@
 
     {% if concept.lang_prefLabels|length > 0 %}
     <tr>
-        <th>Other Language Labels</th>
+        <th style="padding-right: 10px;">Other Language Labels</th>
         <td class="list">
             {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
-                {{ prefLabel }} ({{ lang }})
+                {{ prefLabel }} ({{ lang }})<br>
             {% endfor %}
         </td>
     </tr>
@@ -63,73 +63,26 @@
 
     {% endif %}
 
-    {% if concept.exactMatches %}
-        <tr>
-            <th>has exact match:</th>
-            {% for match in concept.exactMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
+    {% for relationship, relationship_label in [
+        ('exactMatch', 'has exact match'),
+        ('closeMatch', 'has close match'),
+        ('broadMatch', 'has broad match'),
+        ('narrowMatch', 'has narrow match'),
+        ('broader', 'Broader'),
+        ('narrower', 'Narrower'),
+        ] %}
 
-    {% if concept.closeMatches %}
-        <tr>
-            <th>has close match:</th>
-            {% for match in concept.closeMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broadMatches %}
-        <tr>
-            <th>has broad match:</th>
-            {% for match in concept.broadMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.narrowMatches %}
-        <tr>
-            <th>has narrow match:</th>
-            {% for match in concept.narrowMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.relatedMatches %}
-        <tr>
-            <th>has related match:</th>
-            {% for match in concept.relatedMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broaders|length > 0 %}
-    <tr>
-        {% if concept.broaders %}
-        <th>Broader</th>
-        <td class="list">
-            {% for broader in concept.broaders -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(broader) }}">{{ h.make_title(broader) }}</a><br />
-            {% endfor %}
-        </td>
-        {% endif %}
-    </tr>
-    {% endif %}
-    {% if concept.narrowers %}
-    <tr>
-        <th style="padding-right: 10px;">Narrower: </th>
-        <td class="list">
-            {% for narrower in concept.narrowers -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(narrower) }}">{{ h.make_title(narrower) }}</a><br />
-            {% endfor %}
-        </td>
-    </tr>
-    {% endif %}
+        {% if concept.concept_relationships[relationship] -%}
+            <tr>
+                <th style="padding-right: 10px;">{{relationship_label}}:</th>
+                <td class="list">
+                    {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
+                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    {% endfor -%}
+                </td>
+            </tr>
+        {% endif -%}
+    {% endfor -%}
 </table>
 <hr>
 <h3>Alternate views</h3>

--- a/view/generic/templates/concept.html
+++ b/view/generic/templates/concept.html
@@ -18,6 +18,18 @@
         <td>{{ concept.modified }}</td>
     </tr>
     {% endif %}
+
+    {% if concept.lang_prefLabels|length > 0 %}
+    <tr>
+        <th>Other Language Labels</th>
+        <td class="list">
+            {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
+                {{ prefLabel }} ({{ lang }})
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+
     {% if concept.altLabels|length > 0 %}
     <tr>
         <th>Alternative Labels</th>
@@ -28,7 +40,6 @@
         </td>
     </tr>
     {% endif %}
-
     <!-- don't display hiddenLabels, duh! -->
 
     {%  if concept.definition is not none  %}

--- a/view/generic/templates/concept.html
+++ b/view/generic/templates/concept.html
@@ -75,7 +75,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
+                    <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(concept_uri) }}>{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/generic/templates/concept.html
+++ b/view/generic/templates/concept.html
@@ -21,10 +21,10 @@
 
     {% if concept.lang_prefLabels|length > 0 %}
     <tr>
-        <th>Other Language Labels</th>
+        <th style="padding-right: 10px;">Other Language Labels</th>
         <td class="list">
             {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
-                {{ prefLabel }} ({{ lang }})
+                {{ prefLabel }} ({{ lang }})<br>
             {% endfor %}
         </td>
     </tr>
@@ -61,74 +61,27 @@
         <th>Source</th><td>{{ format(concept.source) }}</td>
     </tr>
     {% endif %}
+    {% for relationship, relationship_label in [
+        ('exactMatch', 'has exact match'),
+        ('closeMatch', 'has close match'),
+        ('broadMatch', 'has broad match'),
+        ('narrowMatch', 'has narrow match'),
+        ('broader', 'Broader'),
+        ('narrower', 'Narrower'),
+        ] %}
 
-    {% if concept.exactMatches %}
-        <tr>
-            <th>has exact match:</th>
-            {% for match in concept.exactMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
+        {% if concept.concept_relationships[relationship] -%}
+            <tr>
+                <th style="padding-right: 10px;">{{relationship_label}}:</th>
+                <td class="list">
+                    {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
+                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    {% endfor -%}
+                </td>
+            </tr>
+        {% endif -%}
+    {% endfor -%}
 
-    {% if concept.closeMatches %}
-        <tr>
-            <th>has close match:</th>
-            {% for match in concept.closeMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broadMatches %}
-        <tr>
-            <th>has broad match:</th>
-            {% for match in concept.broadMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.narrowMatches %}
-        <tr>
-            <th>has narrow match:</th>
-            {% for match in concept.narrowMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.relatedMatches %}
-        <tr>
-            <th>has related match:</th>
-            {% for match in concept.relatedMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broaders|length > 0 %}
-    <tr>
-        {% if concept.broaders %}
-        <th>Broader</th>
-        <td class="list">
-            {% for broader in concept.broaders -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(broader) }}">{{ h.make_title(broader) }}</a><br />
-            {% endfor %}
-        </td>
-        {% endif %}
-    </tr>
-    {% endif %}
-    {% if concept.narrowers %}
-    <tr>
-        <th>Narrower: </th>
-        <td class="list">
-            {% for narrower in concept.narrowers -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(narrower) }}">{{ h.make_title(narrower) }}</a><br />
-            {% endfor %}
-        </td>
-    </tr>
-    {% endif %}
 </table>
 <hr>
 <h3>Alternate views</h3>

--- a/view/generic/templates/concept.html
+++ b/view/generic/templates/concept.html
@@ -75,7 +75,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/gsq/templates/concept.html
+++ b/view/gsq/templates/concept.html
@@ -76,7 +76,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
+                    <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/gsq/templates/concept.html
+++ b/view/gsq/templates/concept.html
@@ -76,7 +76,7 @@
                 <th style="padding-right: 10px;">{{relationship_label}}:</th>
                 <td class="list">
                     {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
-                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    <a href="{{ concept_uri }}">{{ concept_label }}</a><br>
                     {% endfor -%}
                 </td>
             </tr>

--- a/view/gsq/templates/concept.html
+++ b/view/gsq/templates/concept.html
@@ -7,7 +7,7 @@
 <table class="metadata concept">
     {% if concept.created %}
     <tr>
-        <th>Date created:</th>
+        <th style="padding-right: 10px;">Date created:</th>
         <td>{{ concept.created }}</td>
     </tr>
     {% endif %}
@@ -18,6 +18,18 @@
         <td>{{ concept.modified }}</td>
     </tr>
     {% endif %}
+
+    {% if concept.lang_prefLabels|length > 0 %}
+    <tr>
+        <th style="padding-right: 10px;">Other Language Labels</th>
+        <td class="list">
+            {% for lang, prefLabel in concept.lang_prefLabels.items() -%}
+                {{ prefLabel }} ({{ lang }})<br>
+            {% endfor %}
+        </td>
+    </tr>
+    {% endif %}
+
     {% if concept.altLabels|length > 0 %}
     <tr>
         <th>Alternative Labels</th>
@@ -50,74 +62,26 @@
         <th>Source</th><td>{{ format(concept.source) }}</td>
     </tr>
     {% endif %}
+    {% for relationship, relationship_label in [
+        ('exactMatch', 'has exact match'),
+        ('closeMatch', 'has close match'),
+        ('broadMatch', 'has broad match'),
+        ('narrowMatch', 'has narrow match'),
+        ('broader', 'Broader'),
+        ('narrower', 'Narrower'),
+        ] %}
 
-    {% if concept.exactMatches %}
-        <tr>
-            <th>has exact match:</th>
-            {% for match in concept.exactMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.closeMatches %}
-        <tr>
-            <th>has close match:</th>
-            {% for match in concept.closeMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broadMatches %}
-        <tr>
-            <th>has broad match:</th>
-            {% for match in concept.broadMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.narrowMatches %}
-        <tr>
-            <th>has narrow match:</th>
-            {% for match in concept.narrowMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.relatedMatches %}
-        <tr>
-            <th>has related match:</th>
-            {% for match in concept.relatedMatches %}
-                <td><a href="{{ match }}">{{ h.make_title(match) }}</a></td>
-            {% endfor %}
-        </tr>
-    {% endif %}
-
-    {% if concept.broaders|length > 0 %}
-    <tr>
-        {% if concept.broaders %}
-        <th>Broader</th>
-        <td class="list">
-            {% for broader in concept.broaders -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(broader) }}">{{ h.make_title(broader) }}</a><br />
-            {% endfor %}
-        </td>
-        {% endif %}
-    </tr>
-    {% endif %}
-    {% if concept.narrowers %}
-    <tr>
-        <th style="padding-right: 10px;">Narrower: </th>
-        <td class="list">
-            {% for narrower in concept.narrowers -%}
-            <a href="{{ request.base_url }}?vocab_id={{ vocab_id }}&uri={{ h.url_encode(narrower) }}">{{ h.make_title(narrower) }}</a><br />
-            {% endfor %}
-        </td>
-    </tr>
-    {% endif %}
+        {% if concept.concept_relationships[relationship] -%}
+            <tr>
+                <th style="padding-right: 10px;">{{relationship_label}}:</th>
+                <td class="list">
+                    {% for concept_uri, concept_label in concept.concept_relationships[relationship].items() -%}
+                    <a href="{{ h.url_encode(concept_uri) }}">{{ concept_label }}</a><br>
+                    {% endfor -%}
+                </td>
+            </tr>
+        {% endif -%}
+    {% endfor -%}
 </table>
 <hr>
 <h3>Alternate views</h3>


### PR DESCRIPTION
G'day Nick & Edmond...
I've implemented the first cut of multilingual support.
There is now an optional row in the table in the concept template which shows prefLabels in any languages other than the default one.
The "lang=<language_code>" parameter has been implemented for most of the pages - that is mainly done in the Source object.
Note that if you don't have a DEFAULT_LANGUAGE value in the config, it will default to 'en'.
I've updated all of the templates in the various branches - there should be no effect for vocabs where the prefLabels are all of language "en" or have no language specified.
There are also some minor changes I made to get the SPARQL form to work properly - could you please check that form to make sure I haven't broken anything.
Cheers,
Alex